### PR TITLE
chore: pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+ pre-push:
+   parallel: true
+   commands:
+     lint:
+       run: deno lint
+     format:
+       run: deno fmt --check


### PR DESCRIPTION
Initializes `lefthook` in local workspaces to run pre-push commands